### PR TITLE
Fixing issues in timestamp MQTT publisher

### DIFF
--- a/publish_mqtt.py
+++ b/publish_mqtt.py
@@ -1,5 +1,6 @@
 import json
 import time
+from datetime import datetime
 from typing import Dict, Any
 
 import paho.mqtt.client as mqtt
@@ -8,10 +9,10 @@ from NovaApi.ExecuteAction.LocateTracker.location_request import get_location_da
 from ProtoDecoders.decoder import parse_device_list_protobuf, get_canonic_ids
 
 # MQTT Configuration
-MQTT_BROKER = "192.168.1.10"  # Change this to your MQTT broker address
+MQTT_BROKER = "localhost"       # Replace with your MQTT broker address
 MQTT_PORT = 1883
-MQTT_USERNAME = None  # Set your MQTT username if required
-MQTT_PASSWORD = None  # Set your MQTT password if required
+MQTT_USERNAME = "username"              # Optional: set your MQTT username
+MQTT_PASSWORD = "password"            # Optional: set your MQTT password
 MQTT_CLIENT_ID = "google_find_my_publisher"
 
 # Home Assistant MQTT Discovery
@@ -19,14 +20,14 @@ DISCOVERY_PREFIX = "homeassistant"
 DEVICE_PREFIX = "google_find_my"
 
 def on_connect(client, userdata, flags, result_code, properties):
-    """Callback when connected to MQTT broker"""
-    print(f"Connected to MQTT broker with result code {result_code}")
+    print(f"[MQTT] Connected to broker with result code {result_code}")
 
 def publish_device_config(client: mqtt.Client, device_name: str, canonic_id: str) -> None:
-    """Publish Home Assistant MQTT discovery configuration for a device"""
+    """
+    Publishes the MQTT discovery configuration for Home Assistant
+    """
     base_topic = f"{DISCOVERY_PREFIX}/device_tracker/{DEVICE_PREFIX}_{canonic_id}"
-    
-    # Device configuration for Home Assistant
+
     config = {
         "unique_id": f"{DEVICE_PREFIX}_{canonic_id}",
         "state_topic": f"{base_topic}/state",
@@ -39,78 +40,83 @@ def publish_device_config(client: mqtt.Client, device_name: str, canonic_id: str
             "manufacturer": "Google"
         }
     }
-    print(f"{base_topic}/config")
-    # Publish discovery config
-    r = client.publish(f"{base_topic}/config", json.dumps(config), retain=True)
-    return r
+
+    client.publish(f"{base_topic}/config", json.dumps(config), retain=True)
 
 def publish_device_state(client: mqtt.Client, device_name: str, canonic_id: str, location_data: Dict) -> None:
-    """Publish device state and attributes to MQTT"""
+    """
+    Publishes device state and attributes to MQTT
+    """
     base_topic = f"{DISCOVERY_PREFIX}/device_tracker/{DEVICE_PREFIX}_{canonic_id}"
-    
-    # Extract location data
-    lat = location_data.get('latitude')
-    lon = location_data.get('longitude')
-    accuracy = location_data.get('accuracy')
-    altitude = location_data.get('altitude')
-    timestamp = location_data.get('timestamp', time.time())
-    
-    # Publish state (home/not_home/unknown)
-    state = "unknown"
-    client.publish(f"{base_topic}/state", state)
-    
-    # Publish attributes
-    attributes = {
-        "latitude": lat,
-        "longitude": lon,
-        "altitude": altitude,
-        "gps_accuracy": accuracy,
-        "source_type": "gps",
-        "last_updated": timestamp
-    }
-    r = client.publish(f"{base_topic}/attributes", json.dumps(attributes))
-    return r
+
+    try:
+        lat = location_data.get('latitude')
+        lon = location_data.get('longitude')
+        accuracy = location_data.get('accuracy')
+        altitude = location_data.get('altitude')
+        raw_ts = location_data.get('timestamp', time.time())
+
+        # Normalize timestamp (handles string, milliseconds, and invalid formats)
+        try:
+            if isinstance(raw_ts, str):
+                dt = datetime.strptime(raw_ts, "%Y-%m-%d %H:%M:%S")
+                timestamp = int(dt.timestamp())
+            elif isinstance(raw_ts, (int, float)):
+                timestamp = int(raw_ts)
+                if timestamp > 9999999999:
+                    timestamp = timestamp // 1000  # convert milliseconds to seconds
+            else:
+                raise ValueError(f"Unsupported timestamp format: {raw_ts}")
+        except Exception:
+            timestamp = int(time.time())
+
+        state = "unknown"  # Optional: implement proximity logic for 'home' vs 'not_home'
+        attributes = {
+            "latitude": lat,
+            "longitude": lon,
+            "altitude": altitude,
+            "gps_accuracy": accuracy,
+            "source_type": "gps",
+            "last_updated": timestamp
+        }
+
+        client.publish(f"{base_topic}/state", state)
+        client.publish(f"{base_topic}/attributes", json.dumps(attributes))
+
+    except Exception as e:
+        print(f"[ERROR] Failed to publish state for {device_name}: {e}")
 
 def main():
-    # Initialize MQTT client
     client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, MQTT_CLIENT_ID)
     client.on_connect = on_connect
 
     if MQTT_USERNAME and MQTT_PASSWORD:
         client.username_pw_set(MQTT_USERNAME, MQTT_PASSWORD)
-    
+
     try:
         client.connect(MQTT_BROKER, MQTT_PORT)
         client.loop_start()
-        
-        print("Loading devices...")
+
+        print("[INFO] Loading devices...")
         result_hex = request_device_list()
         device_list = parse_device_list_protobuf(result_hex)
         canonic_ids = get_canonic_ids(device_list)
-        
-        print(f"Found {len(canonic_ids)} devices")
-        
-        # Publish discovery config and state for each device
-        for device_name, canonic_id in canonic_ids:
-            print(f"Processing device: {device_name}")
-            
-            # Publish discovery configuration
-            msg_info = publish_device_config(client, device_name, canonic_id)
-            msg_info.wait_for_publish()
-            
-            # Get and publish location data
-            location_data = get_location_data_for_device(canonic_id, device_name)
-            msg_info = publish_device_state(client, device_name, canonic_id, location_data)
-            msg_info.wait_for_publish()
 
-            print(f"Published data for {device_name}")
-            
-        print("\nAll devices have been published to MQTT")
-        print("Devices will now be discoverable in Home Assistant")
-        print("You may need to restart Home Assistant or trigger device discovery")
-        
+        print(f"[INFO] Found {len(canonic_ids)} devices")
+
+        for device_name, canonic_id in canonic_ids:
+            print(f"[INFO] Publishing: {device_name}")
+            try:
+                publish_device_config(client, device_name, canonic_id)
+                location_data = get_location_data_for_device(canonic_id, device_name)
+                publish_device_state(client, device_name, canonic_id, location_data)
+            except Exception as e:
+                print(f"[ERROR] Failed to process {device_name}: {e}")
+
+        print("[OK] All devices successfully published to MQTT")
+
     except Exception as e:
-        print(f"Error: {e}")
+        print(f"[FATAL] General error: {e}")
     finally:
         client.loop_stop()
         client.disconnect()


### PR DESCRIPTION
This PR introduces `publish_mqtt.py`, a script that publishes tracker locations from Google Find My Tools to an MQTT broker, compatible with Home Assistant's device_tracker discovery.

### ✅ Key features:
- Supports Home Assistant MQTT Discovery (state + attributes).
- Parses and normalizes timestamp values, fixing issues like:
  - `invalid literal for int() with base 10: '2025-05-18 10:37:46'`
  - `int too big to convert` from millisecond values.
  - 
![Captura de pantalla 2025-05-18 a las 13 22 07](https://github.com/user-attachments/assets/9e92a705-96d4-4f2d-9d51-a7d61c69074e)

- Gracefully handles location fetch errors per device.

Tested successfully with multiple Bluetooth and Android trackers.

Let me know if you'd prefer this as an example script or if you'd like further integration.

Thanks for this awesome tool!