### PR TITLE
Configure via env vars, add device ignore list

### DIFF
--- a/publish_mqtt.py
+++ b/publish_mqtt.py
@@ -11,10 +11,17 @@ from NovaApi.ExecuteAction.LocateTracker.location_request import (
 from ProtoDecoders.decoder import parse_device_list_protobuf, get_canonic_ids
 
 # MQTT Configuration
-MQTT_BROKER = "192.168.1.10"  # Change this to your MQTT broker address
-MQTT_PORT = 1883
-MQTT_USERNAME = None  # Set your MQTT username if required
-MQTT_PASSWORD = None  # Set your MQTT password if required
+
+# Configure your MQTT broker address
+MQTT_BROKER: str = os.environ.get("MQTT_BROKER", "localhost")
+MQTT_PORT: int = int(os.environ.get("MQTT_PORT", "1883"))
+MQTT_USERNAME: str = os.environ.get(
+    "MQTT_USERNAME", ""
+)  # Set your MQTT username if required
+MQTT_PASSWORD: str = os.environ.get(
+    "MQTT_PASSWORD", ""
+)  # Set your MQTT password if required
+
 MQTT_CLIENT_ID = "google_find_my_publisher"
 
 # Home Assistant MQTT Discovery


### PR DESCRIPTION
The MR 

* let the user configure the most important config options via environment variables 
* adds a `IGNORE_DEVICES` config option, to ignore certain devices that should not get pushed to the mqtt server